### PR TITLE
transaction, subscription, plan, customer no longer ref static config. Only some methods implemented properly

### DIFF
--- a/lib/braintree/configuration.rb
+++ b/lib/braintree/configuration.rb
@@ -32,6 +32,10 @@ module Braintree
       Braintree::Gateway.new(instantiate)
     end
 
+    def gateway
+      Braintree::Gateway.new(self)
+    end
+
     def self.instantiate # :nodoc:
       config = new(
         :custom_user_agent => @custom_user_agent,

--- a/lib/braintree/customer.rb
+++ b/lib/braintree/customer.rb
@@ -7,13 +7,13 @@ module Braintree
       :phone, :updated_at, :website, :custom_fields, :paypal_accounts, :apple_pay_cards
 
     # See http://www.braintreepayments.com/docs/ruby/customers/search
-    def self.all
-      Configuration.gateway.customer.all
+    def self.all(config)
+      config.gateway.customer.all
     end
 
     # See http://www.braintreepayments.com/docs/ruby/customers/create
     def self.create(attributes = {})
-      Configuration.gateway.customer.create(attributes)
+      config.gateway.customer.create(attributes)
     end
 
     # See http://www.braintreepayments.com/docs/ruby/customers/create
@@ -26,7 +26,7 @@ module Braintree
     # See http://www.braintreepayments.com/docs/ruby/customers/create_tr
     def self.create_customer_url
       warn "[DEPRECATED] Customer.create_customer_url is deprecated. Please use TransparentRedirect.url"
-      Configuration.gateway.customer.create_customer_url
+      config.gateway.customer.create_customer_url
     end
 
     # Deprecated. Use Braintree::TransparentRedirect.confirm
@@ -34,7 +34,7 @@ module Braintree
     # See http://www.braintreepayments.com/docs/ruby/customers/create_tr
     def self.create_from_transparent_redirect(query_string)
       warn "[DEPRECATED] Customer.create_from_transparent_redirect is deprecated. Please use TransparentRedirect.confirm"
-      Configuration.gateway.customer.create_from_transparent_redirect(query_string)
+      config.gateway.customer.create_from_transparent_redirect(query_string)
     end
 
     # See http://www.braintreepayments.com/docs/ruby/transactions/create_from_vault
@@ -49,12 +49,12 @@ module Braintree
 
     # See http://www.braintreepayments.com/docs/ruby/customers/delete
     def self.delete(customer_id)
-      Configuration.gateway.customer.delete(customer_id)
+      config.gateway.customer.delete(customer_id)
     end
 
     # See http://www.braintreepayments.com/docs/ruby/customers/search
-    def self.find(customer_id)
-      Configuration.gateway.customer.find(customer_id)
+    def self.find(config, customer_id)
+      config.gateway.customer.find(customer_id)
     end
 
     # See http://www.braintreepayments.com/docs/ruby/transactions/create_from_vault
@@ -68,18 +68,18 @@ module Braintree
     end
 
     # See http://www.braintreepayments.com/docs/ruby/customers/search
-    def self.search(&block)
-      Configuration.gateway.customer.search(&block)
+    def self.search(config, &block)
+      config.gateway.customer.search(&block)
     end
 
     # Returns a ResourceCollection of transactions for the customer with the given +customer_id+.
     def self.transactions(customer_id, options = {})
-      Configuration.gateway.customer.transactions(customer_id, options = {})
+      config.gateway.customer.transactions(customer_id, options = {})
     end
 
     # See http://www.braintreepayments.com/docs/ruby/customers/update
     def self.update(customer_id, attributes)
-      Configuration.gateway.customer.update(customer_id, attributes)
+      config.gateway.customer.update(customer_id, attributes)
     end
 
     # See http://www.braintreepayments.com/docs/ruby/customers/update
@@ -92,7 +92,7 @@ module Braintree
     # See http://www.braintreepayments.com/docs/ruby/customers/update_tr
     def self.update_customer_url
       warn "[DEPRECATED] Customer.update_customer_url is deprecated. Please use TransparentRedirect.url"
-      Configuration.gateway.customer.update_customer_url
+      config.gateway.customer.update_customer_url
     end
 
     # Deprecated. Use Braintree::TransparentRedirect.confirm
@@ -100,7 +100,7 @@ module Braintree
     # See http://www.braintreepayments.com/docs/ruby/customers/update_tr
     def self.update_from_transparent_redirect(query_string)
       warn "[DEPRECATED] Customer.update_from_transparent_redirect is deprecated. Please use TransparentRedirect.confirm"
-      Configuration.gateway.customer.update_from_transparent_redirect(query_string)
+      config.gateway.customer.update_from_transparent_redirect(query_string)
     end
 
     def initialize(gateway, attributes) # :nodoc:

--- a/lib/braintree/plan.rb
+++ b/lib/braintree/plan.rb
@@ -21,8 +21,8 @@ module Braintree
     attr_reader :add_ons
 
     # See http://www.braintreepayments.com/docs/ruby/plans/all
-    def self.all
-      Configuration.gateway.plan.all
+    def self.all(config)
+      config.gateway.plan.all
     end
 
     def initialize(gateway, attributes) # :nodoc:

--- a/lib/braintree/subscription.rb
+++ b/lib/braintree/subscription.rb
@@ -33,12 +33,12 @@ module Braintree
 
     # See http://www.braintreepayments.com/docs/ruby/subscriptions/cancel
     def self.cancel(subscription_id)
-      Configuration.gateway.subscription.cancel(subscription_id)
+      config.gateway.subscription.cancel(subscription_id)
     end
 
     # See http://www.braintreepayments.com/docs/ruby/subscriptions/create
     def self.create(attributes)
-      Configuration.gateway.subscription.create(attributes)
+      config.gateway.subscription.create(attributes)
     end
 
     def self.create!(attributes)
@@ -47,21 +47,21 @@ module Braintree
 
     # See http://www.braintreepayments.com/docs/ruby/subscriptions/search
     def self.find(id)
-      Configuration.gateway.subscription.find(id)
+      config.gateway.subscription.find(id)
     end
 
     def self.retry_charge(subscription_id, amount=nil)
-      Configuration.gateway.transaction.retry_subscription_charge(subscription_id, amount)
+      config.gateway.transaction.retry_subscription_charge(subscription_id, amount)
     end
 
     # See http://www.braintreepayments.com/docs/ruby/subscriptions/search
-    def self.search(&block)
-      Configuration.gateway.subscription.search(&block)
+    def self.search(config, &block)
+      config.gateway.subscription.search(&block)
     end
 
     # See http://www.braintreepayments.com/docs/ruby/subscriptions/update
     def self.update(subscription_id, attributes)
-      Configuration.gateway.subscription.update(subscription_id, attributes)
+      config.gateway.subscription.update(subscription_id, attributes)
     end
 
     def self.update!(subscription_id, attributes)

--- a/lib/braintree/transaction.rb
+++ b/lib/braintree/transaction.rb
@@ -116,7 +116,7 @@ module Braintree
 
     # See http://www.braintreepayments.com/docs/ruby/transactions/create
     def self.create(attributes)
-      Configuration.gateway.transaction.create(attributes)
+      config.gateway.transaction.create(attributes)
     end
 
     # See http://www.braintreepayments.com/docs/ruby/transactions/create
@@ -125,7 +125,7 @@ module Braintree
     end
 
     def self.cancel_release(transaction_id)
-      Configuration.gateway.transaction.cancel_release(transaction_id)
+      config.gateway.transaction.cancel_release(transaction_id)
     end
 
     def self.cancel_release!(transaction_id)
@@ -133,7 +133,7 @@ module Braintree
     end
 
     def self.clone_transaction(transaction_id, attributes)
-      Configuration.gateway.transaction.clone_transaction(transaction_id, attributes)
+      config.gateway.transaction.clone_transaction(transaction_id, attributes)
     end
 
     def self.clone_transaction!(transaction_id, attributes)
@@ -145,7 +145,7 @@ module Braintree
     # See http://www.braintreepayments.com/docs/ruby/transactions/create_tr
     def self.create_from_transparent_redirect(query_string)
       warn "[DEPRECATED] Transaction.create_from_transparent_redirect is deprecated. Please use TransparentRedirect.confirm"
-      Configuration.gateway.transaction.create_from_transparent_redirect(query_string)
+      config.gateway.transaction.create_from_transparent_redirect(query_string)
     end
 
     # Deprecated. Use Braintree::TransparentRedirect.url
@@ -153,11 +153,11 @@ module Braintree
     # See http://www.braintreepayments.com/docs/ruby/transactions/create_tr
     def self.create_transaction_url
       warn "[DEPRECATED] Transaction.create_transaction_url is deprecated. Please use TransparentRedirect.url"
-      Configuration.gateway.transaction.create_transaction_url
+      config.gateway.transaction.create_transaction_url
     end
 
     def self.credit(attributes)
-      Configuration.gateway.transaction.credit(attributes)
+      config.gateway.transaction.credit(attributes)
     end
 
     def self.credit!(attributes)
@@ -166,11 +166,11 @@ module Braintree
 
     # See http://www.braintreepayments.com/docs/ruby/transactions/search
     def self.find(id)
-      Configuration.gateway.transaction.find(id)
+      config.gateway.transaction.find(id)
     end
 
     def self.hold_in_escrow(id)
-      Configuration.gateway.transaction.hold_in_escrow(id)
+      config.gateway.transaction.hold_in_escrow(id)
     end
 
     def self.hold_in_escrow!(id)
@@ -179,7 +179,7 @@ module Braintree
 
     # See http://www.braintreepayments.com/docs/ruby/transactions/refund
     def self.refund(id, amount = nil)
-      Configuration.gateway.transaction.refund(id, amount)
+      config.gateway.transaction.refund(id, amount)
     end
 
     # See http://www.braintreepayments.com/docs/ruby/transactions/refund
@@ -189,7 +189,7 @@ module Braintree
 
     # See http://www.braintreepayments.com/docs/ruby/transactions/create
     def self.sale(attributes)
-      Configuration.gateway.transaction.sale(attributes)
+      config.gateway.transaction.sale(attributes)
     end
 
     # See http://www.braintreepayments.com/docs/ruby/transactions/create
@@ -198,12 +198,12 @@ module Braintree
     end
 
     # See http://www.braintreepayments.com/docs/ruby/transactions/search
-    def self.search(&block)
-      Configuration.gateway.transaction.search(&block)
+    def self.search(config, &block)
+      config.gateway.transaction.search(&block)
     end
 
     def self.release_from_escrow(transaction_id)
-      Configuration.gateway.transaction.release_from_escrow(transaction_id)
+      config.gateway.transaction.release_from_escrow(transaction_id)
     end
 
     def self.release_from_escrow!(transaction_id)
@@ -212,7 +212,7 @@ module Braintree
 
     # See http://www.braintreepayments.com/docs/ruby/transactions/submit_for_settlement
     def self.submit_for_settlement(transaction_id, amount = nil)
-      Configuration.gateway.transaction.submit_for_settlement(transaction_id, amount)
+      config.gateway.transaction.submit_for_settlement(transaction_id, amount)
     end
 
     # See http://www.braintreepayments.com/docs/ruby/transactions/submit_for_settlement
@@ -222,7 +222,7 @@ module Braintree
 
     # See http://www.braintreepayments.com/docs/ruby/transactions/void
     def self.void(transaction_id)
-      Configuration.gateway.transaction.void(transaction_id)
+      config.gateway.transaction.void(transaction_id)
     end
 
     # See http://www.braintreepayments.com/docs/ruby/transactions/void


### PR DESCRIPTION
# What is this?

This PR changes the following classes: `:transaction`, `subscription`, `:plan`, `:customer` so that they no longer reference the static `Configuration` class.
# Awesome so you fixed it all up and everything?

No. This is mainly for my use so I only fixed the methods I'm interested in for those classes. I did remove references to the static class completely, however I didn't change the implementation on the methods I'm not interested in, for now.
# Oh, I see. And that's all you had to do to get it working?

Not quite. I also had to make `.gateway` an instance method in the `Configuration` class.
